### PR TITLE
[FEAT] Use headers instead to build backend services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleCloudPlatform/firestore-gorilla-sessions
+module github.com/loveholidays/firestore-gorilla-sessions
 
 go 1.11
 

--- a/store_test.go
+++ b/store_test.go
@@ -57,9 +57,6 @@ func TestStore(t *testing.T) {
 		t.Errorf("Save: %v", err)
 	}
 
-	// Subsequent requests include the cookie.
-	r.Header.Set("Cookie", rr.Header().Get("Set-Cookie"))
-
 	got, err := s.Get(r, name)
 	if err != nil {
 		t.Errorf("Get: %v", err)


### PR DESCRIPTION
We probably will never use the cookie based version so i replaced it completely with a header based architecture.