### PR TITLE
Adding expire field that we can use to query expired session

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "store_test.go",
+            "env": {
+                "GOOGLE_CLOUD_PROJECT": "lh-frontend-staging",
+            }
+        }
+    ]
+}

--- a/store.go
+++ b/store.go
@@ -15,7 +15,7 @@
 // Package firestoregorilla is a Firestore-backed sessions store, which can be
 // used with gorilla/sessions.
 //
-// Encoded sessions are stored in Firestore
+// # Encoded sessions are stored in Firestore
 //
 // Sessions never expire and are never deleted or cleaned up.
 package firestoregorilla
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/gorilla/sessions"
@@ -47,7 +48,7 @@ var _ sessions.Store = &Store{}
 // document.
 type sessionDoc struct {
 	EncodedSession string
-	Expire         int
+	Expire         time.Time
 }
 
 type sessionDocValue struct {
@@ -144,7 +145,10 @@ func (s *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.S
 
 	encoded := sessionDoc{
 		EncodedSession: sessionString,
-		Expire:         expire,
+	}
+
+	if expire != 0 {
+		encoded.Expire = time.Unix(int64(expire), 10)
 	}
 
 	if _, err := s.client.Collection(session.Name()).Doc(id).Set(r.Context(), encoded); err != nil {

--- a/store_test.go
+++ b/store_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/google/go-cmp/cmp"
@@ -51,6 +52,7 @@ func TestStore(t *testing.T) {
 	defer s.cleanup(name)
 
 	session.Values["testkey"] = "testvalue"
+	session.Values["expire"] = int(time.Now().Unix())
 
 	rr := httptest.NewRecorder()
 	if err := s.Save(r, rr, session); err != nil {


### PR DESCRIPTION
## Description
Currently we're cleaning sessions by selecting as much as we can and parsing the json to check the value. This will put the expire into a field then we can use the TTL feature from firestore.

In the future we shouldn't use `firestore-gorilla-sessions` as we're not storing as a document.


### Before releasing session-manager
- [X] Test old session vs new
- [X] Sometimes expire is set to 0 (needs fix it)
